### PR TITLE
Some fixes I had in my queue

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -53,9 +53,17 @@ if [ -n "$RENDER" ]; then
         cp -a "$f" "$LOCAL/"
     done
     pushd "$LOCAL/"
+    shopt -s nullglob
+    copied=
         for i in *-label*.png ; do
             ln -s $i ${i//-label} ;
+            copied=1
         done
+    shopt -u nullglob
+    if [ ! -n "$copied" ]; then
+       echo "There seems to be no generated images. Please check the output of \"./render.py $RFLAGS $LOCAL/\""
+       exit 1
+    fi
     popd
 fi
 

--- a/cron.sh
+++ b/cron.sh
@@ -11,12 +11,14 @@ set -e
 VERBOSE=
 RENDER=
 REMOTE=
-while getopts 'vREB' v; do
+GIT_PULL=
+while getopts 'vREBG' v; do
     case $v in
         v) VERBOSE=1;;
         R) REMOTE=1;;
         E) RENDER=1;;
         B) BINARY=1;;
+        G) GIT_PULL=1;;
         *) echo "ERROR: unsupported parameter -$v">&2; exit 1;;
     esac
 done
@@ -24,6 +26,14 @@ shift $(( $OPTIND - 1 ))
 
 RFLAGS=""
 [ -n "$VERBOSE" ] && RFLAGS="$RFLAGS -v"
+
+if [ -n "$GIT_PULL" ]; then
+    cd "$BASEDIR"
+    GFLAGS=""
+    [ -n "$VERBOSE" ] && GFLAGS="$GFLAGS --verbose"
+    git pull --ff-only $GFLAGS
+fi
+
 
 mkdir -p "$LOCAL"
 /bin/rm -f "$LOCAL"/*.png

--- a/render.py
+++ b/render.py
@@ -18,12 +18,14 @@ import tempfile
 import shutil
 import atexit
 
+# VERSION should be a release number or "conference" as in the following examples:
+# VERSION = "13.2"
+# VERSION = "conference"
 VERSION = "13.2"
+
+# UTC timestamp!
 RELEASE = datetime.datetime(2014, 11, 04, 12, 0, 0)
 
-#VERSION = "conference"
-# UTC timestamp!
-#RELEASE = datetime.datetime(2015, 05, 01, 8, 0, 0)
 
 VARIANTS = ["label", "nolabel"]
 

--- a/render.py
+++ b/render.py
@@ -303,6 +303,9 @@ def render(lang, truelang, top1, top2, center, bottom1, bottom2, template_varian
                 if options.verbose:
                     print "skipping %s / %s / %s: template \"%s\" does not exist" % (lang, var, size[2], template)
                     pass
+                if var:
+                    print >>sys.stderr, "Needed template \"%s\" is missing. Aborting" % (template)
+                    sys.exit(1)
                 continue
 
             outfile = "%s/%s%s.%s.png" % (outdir, size[2], var, lang)

--- a/render.py
+++ b/render.py
@@ -18,12 +18,12 @@ import tempfile
 import shutil
 import atexit
 
-#VERSION = "13.2"
-#RELEASE = datetime.datetime(2014, 11, 04, 12, 0, 0)
+VERSION = "13.2"
+RELEASE = datetime.datetime(2014, 11, 04, 12, 0, 0)
 
-VERSION = "conference"
+#VERSION = "conference"
 # UTC timestamp!
-RELEASE = datetime.datetime(2015, 05, 01, 8, 0, 0)
+#RELEASE = datetime.datetime(2015, 05, 01, 8, 0, 0)
 
 VARIANTS = ["label", "nolabel"]
 


### PR DESCRIPTION
Fixes #10 and #11 by exiting when there are no files to iterate in a for loop or when it's not able to find a template image to render a banner.
Added a -G option in cron.sh to update the scripts from git (only fast-forward).
Changed the (already past) target to reference the release again, instead of the conference.