### PR TITLE
Preparing Leap 15.2

### DIFF
--- a/render.py
+++ b/render.py
@@ -19,10 +19,10 @@ import atexit
 # VERSION should be a release number or "conference" as in the following examples:
 # VERSION = "13.2"
 # VERSION = "conference"
-VERSION = "15.1"
+VERSION = "15.2"
 
 # UTC timestamp!
-RELEASE = datetime.datetime(2019, 05, 22, 12, 0, 0)
+RELEASE = datetime.datetime(2020, 07, 02, 12, 0, 0)
 
 
 VARIANTS = ["label", "nolabel"]


### PR DESCRIPTION
Changed values for Leap 15.2 and 2020-07-02 according to https://en.opensuse.org/openSUSE:Roadmap#Upcoming_openSUSE_Leap_Release