### PR TITLE
Prepare for Leap 15.5 release

### DIFF
--- a/render.py
+++ b/render.py
@@ -19,10 +19,10 @@ import atexit
 # VERSION should be a release number or "conference" as in the following examples:
 # VERSION = "13.2"
 # VERSION = "conference"
-VERSION = "15.4"
+VERSION = "15.5"
 
 # UTC timestamp!
-RELEASE = datetime.datetime(2022, 6, 8, 12, 0, 0)
+RELEASE = datetime.datetime(2023, 6, 7, 12, 0, 0)
 
 
 VARIANTS = ["label", "nolabel"]


### PR DESCRIPTION
Changed values for Leap 15.5 and release date Jun 7th 2023 12:00 UTC according to [openSUSE:Roadmap](https://en.opensuse.org/openSUSE:Roadmap#Schedule_for_openSUSE_Leap_15.5)

Link to action ticket: [#114022](https://progress.opensuse.org/issues/114022)

CC: @lkocman 