### PR TITLE
Prepare to Leap 15.6 release

### DIFF
--- a/render.py
+++ b/render.py
@@ -19,10 +19,10 @@ import atexit
 # VERSION should be a release number or "conference" as in the following examples:
 # VERSION = "13.2"
 # VERSION = "conference"
-VERSION = "15.5"
+VERSION = "15.6"
 
 # UTC timestamp!
-RELEASE = datetime.datetime(2023, 6, 7, 12, 0, 0)
+RELEASE = datetime.datetime(2024, 6, 12, 12, 0, 0)
 
 
 VARIANTS = ["label", "nolabel"]


### PR DESCRIPTION
Changed values for Leap 15.6 and release date Jun 12th 2024 12:00 UTC according to [openSUSE:Roadmap](https://en.opensuse.org/openSUSE:Roadmap#Schedule_for_openSUSE_Leap_15.6)

CC: @lkocman 