### PR TITLE
Switch to CairoSVG

### DIFF
--- a/render.py
+++ b/render.py
@@ -4,14 +4,15 @@
 #
 # Release countdown banner generation script
 # by Pascal Bleser <pascal.bleser@opensuse.org>
+# and other openSUSE contributors
 
 import sys
 import datetime
 import fileinput
+from cairosvg import svg2png
 from functools import reduce
 from optparse import OptionParser
 import os
-import subprocess
 import tempfile
 import shutil
 import atexit
@@ -293,14 +294,6 @@ def sjoin(a, sep, b):
     r += b
     return r
 
-def call_render(workfile, outfile, width, height):
-    # can't use rsvg as the black outline around placeholers is
-    # stored in a way only inkscape can process
-    #rc = subprocess.call(["rsvg-convert", "-w", str(width), "-h", str(height), "-f", "png", "-o", outfile, workfile])
-    rc = subprocess.call(["inkscape", "-z", "--export-png=%s" % outfile, "--export-area-page", "-w", str(width), "-h", str(height), workfile], stdout=dev_null)
-    return rc
-
-
 def render(lang, truelang, top1, top2, center, bottom1, bottom2, template_variant=None):
     x = str(center).encode('ascii', 'xmlcharrefreplace')
     y = str(top1).encode('ascii', 'xmlcharrefreplace')
@@ -362,15 +355,12 @@ def render(lang, truelang, top1, top2, center, bottom1, bottom2, template_varian
 
                     out.write(line)
 
-            rc = call_render(workfile, outfile, size[0], size[1])
+            svg2png(url=workfile, write_to=outfile, output_width=size[0], output_height=size[1])
             if options.keep:
                 svg_outfile = "%s/%s%s.%s.svg" % (outdir, size[3], var, lang)
                 shutil.copyfile(workfile, svg_outfile)
                 if options.verbose:
                     print("SVG saved as %s" % svg_outfile)
-
-            if rc != 0:
-                print("ERROR: call to inkscape failed for %s" % workfile, file=sys.stderr)
 
 if options.verbose:
     print("days: %d" % (days))


### PR DESCRIPTION
No longer shell out to Inkscape to reduce external dependencies and to improve speed.

---

Not fully sure about the result, opening a rendered PNG before and after in Gwenview, I don't spot much of a difference, but the metadata suggests there to be one:

```
$ file tmp*/medium-label.af.png
tmp-new/medium-label.af.png: PNG image data, 256 x 256, 8-bit/color RGB, non-interlaced
tmp-old/medium-label.af.png: PNG image data, 256 x 256, 8-bit/color RGBA, non-interlaced

$ identify tmp*/medium-label.af.png
tmp-new/medium-label.af.png PNG 256x256 256x256+0+0 8-bit sRGB 10498B 0.000u 0:00.000
tmp-old/medium-label.af.png PNG 256x256 256x256+0+0 8-bit sRGB 12313B 0.000u 0:00.000
```

`svg2png()` supports passing a `background_color` argument in the form of a color name or `rgba(x,x,x,x)`, but it seems the default background color already is "white" before and after:

```
$ identify -verbose tmp*/medium-label.af.png|grep 'Background color: '
  Background color: white
  Background color: white
```

Leaving as draft until clarified if the RGB difference is actually a problem (and/or how to make svg2png return the same data) - input welcome.

---

Follows https://gitlab.infra.opensuse.org/infra/salt/-/issues/30.